### PR TITLE
Generic filtering for JSON fields with better API interactions

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -15,7 +15,7 @@ config :tesla,
     {Tesla.Adapter.Hackney,
      [
        recv_timeout: 30_000,
-       ssl_options: [verify: :verify_none]
+       ssl_options: [verify: :verify_peer, cacerts: :public_key.cacerts_get()]
      ]}
 
 config :dora, :explorer, refresh_rate: 30_000


### PR DESCRIPTION
Why:
 - We already had a simple filtering mechanism for Events and Projections, to be used by the API. However, it still required manual addition to the code in order to work.
 - Every time a request to an outside HTTP API was made we were getting certificate warnings by Erlang.

How:
 - This PR introduces a generic filtering system for the JSON fields inside the `Projection` and `Event` models. This way, it's unnecessary to further change the API code, if you start indexing new types of Events or create new Projections, with different fields.
 - It also introduces the fix for the Certificates warning, using the new v25+ Erlang `:public_key.cacerts_get()`. ([More info in the docs](https://www.erlang.org/blog/my-otp-25-highlights/#ca-certificates-can-be-fetched-from-the-os-standard-place))