### PR TITLE
Handle maximum Block difference requests and other fixes

### DIFF
--- a/lib/dora/contracts.ex
+++ b/lib/dora/contracts.ex
@@ -1,7 +1,9 @@
 defmodule Dora.Contracts do
-  import Ecto.Query, warn: false
-  alias Dora.Repo
+  @moduledoc false
 
+  import Ecto.Query, warn: false
+
+  alias Dora.Repo
   alias Dora.Contracts.Contract
 
   def list_contracts do
@@ -12,10 +14,10 @@ defmodule Dora.Contracts do
 
   def get_contract_by_address(address), do: Repo.get_by(Contract, address: address)
 
-  def contract_last_block(address) do
+  def contract_information(address) do
     case Repo.get_by(Contract, address: address) do
-      nil -> 0
-      contract -> contract.last_block
+      nil -> {0, nil}
+      contract -> {contract.last_block, contract.abi_path}
     end
   end
 

--- a/lib/dora/contracts/contract.ex
+++ b/lib/dora/contracts/contract.ex
@@ -1,4 +1,6 @@
 defmodule Dora.Contracts.Contract do
+  @moduledoc false
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/dora/event_dispatcher.ex
+++ b/lib/dora/event_dispatcher.ex
@@ -1,4 +1,6 @@
 defmodule Dora.EventDispatcher do
+  @moduledoc false
+
   require Logger
 
   def dispatch(contract_address, {:error, decoded_event}) do

--- a/lib/dora/events.ex
+++ b/lib/dora/events.ex
@@ -1,4 +1,6 @@
 defmodule Dora.Events do
+  @moduledoc false
+
   alias Dora.Repo
   alias Dora.Events.Event
 

--- a/lib/dora/events/event.ex
+++ b/lib/dora/events/event.ex
@@ -1,4 +1,6 @@
 defmodule Dora.Events.Event do
+  @moduledoc false
+
   use Ecto.Schema
 
   import Ecto.Changeset

--- a/lib/dora/explorer/http_rpc.ex
+++ b/lib/dora/explorer/http_rpc.ex
@@ -1,14 +1,38 @@
 defmodule Dora.Explorer.HttpRpc do
+  @moduledoc false
+
   require Logger
   use Tesla
 
+  alias Dora.Utils
+
   @http_rpc Application.compile_env!(:dora, :explorer)[:http_rpc_endpoint]
+  @maximum_blocks_from_the_past 60_400
 
   plug(Tesla.Middleware.BaseUrl, @http_rpc)
   plug(Tesla.Middleware.Headers, [{"accept", "*/*"}])
   plug(Tesla.Middleware.JSON)
 
+  def latest_block do
+    body = %{
+      id: 1,
+      jsonrpc: "2.0",
+      method: "Filecoin.EthBlockNumber",
+      params: []
+    }
+
+    post("/", body)
+    |> handle_block_number()
+  end
+
   def events(address, from_block) do
+    {from, to} =
+      if latest_block() - @maximum_blocks_from_the_past > from_block do
+        {from_block, from_block + @maximum_blocks_from_the_past}
+      else
+        {from_block, "latest"}
+      end
+
     body = %{
       id: 0,
       jsonrpc: "2.0",
@@ -16,14 +40,28 @@ defmodule Dora.Explorer.HttpRpc do
       params: [
         %{
           address: [address],
-          fromBlock: to_string(from_block),
-          toBlock: "latest"
+          fromBlock: Utils.int_to_hex(from),
+          toBlock: Utils.int_to_hex(to)
         }
       ]
     }
 
     post("/", body)
     |> handle_events(address, from_block)
+  end
+
+  defp handle_block_number({:ok, %Tesla.Env{status: 200, body: body}}) do
+    Utils.hex_to_int(body["result"])
+  end
+
+  defp handle_block_number(_) do
+    Logger.error("Error requesting latest block")
+    0
+  end
+
+  defp handle_events({:ok, %Tesla.Env{status: 200, body: %{"error" => error}}}, address, _) do
+    Logger.error("Error requesting events: #{address}. Error #{inspect(error)}")
+    []
   end
 
   defp handle_events({:ok, %Tesla.Env{status: 200, body: body}}, _, _) do

--- a/lib/dora/handlers/defaults/transfer.ex
+++ b/lib/dora/handlers/defaults/transfer.ex
@@ -1,4 +1,6 @@
 defmodule Dora.Handlers.Defaults.Transfer do
+  @moduledoc false
+
   require Logger
 
   alias Dora.{Events, Projections, Repo}

--- a/lib/dora/projections.ex
+++ b/lib/dora/projections.ex
@@ -1,4 +1,6 @@
 defmodule Dora.Projections do
+  @moduledoc false
+
   alias Dora.Projections.EventProjection
   alias Dora.Repo
 

--- a/lib/dora/projections/event_projection.ex
+++ b/lib/dora/projections/event_projection.ex
@@ -1,4 +1,6 @@
 defmodule Dora.Projections.EventProjection do
+  @moduledoc false
+
   use Ecto.Schema
 
   import Ecto.Changeset

--- a/lib/dora/repo.ex
+++ b/lib/dora/repo.ex
@@ -1,4 +1,6 @@
 defmodule Dora.Repo do
+  @moduledoc false
+
   use Ecto.Repo,
     otp_app: :dora,
     adapter: Ecto.Adapters.Postgres

--- a/lib/dora/utils.ex
+++ b/lib/dora/utils.ex
@@ -1,4 +1,8 @@
-defmodule Dora.Handlers.Utils do
+defmodule Dora.Utils do
+  @moduledoc false
+
+  require Logger
+
   def build_topics_maps(topics) do
     Enum.reduce(topics, %{}, fn {name, type, _indexed, value}, acc ->
       Map.put(acc, name, parse_value(value, type))
@@ -15,6 +19,12 @@ defmodule Dora.Handlers.Utils do
     String.pad_leading(data, 64, "0")
     |> Base.decode16!(case: :mixed)
   end
+
+  def hex_to_int("0x" <> value), do: String.to_integer(value, 16)
+  def hex_to_int(value), do: Logger.error("Invalid hex value: #{value}")
+
+  def int_to_hex("latest"), do: "latest"
+  def int_to_hex(value) when is_integer(value), do: "0x#{Integer.to_string(value, 16)}"
 
   defp parse_value(value, "address") when is_binary(value),
     do: String.downcase("0x#{Base.encode16(value)}")

--- a/lib/dora_web/telemetry.ex
+++ b/lib/dora_web/telemetry.ex
@@ -1,4 +1,6 @@
 defmodule DoraWeb.Telemetry do
+  @moduledoc false
+
   use Supervisor
   import Telemetry.Metrics
 

--- a/lib/mix/tasks/dora.gen.handler.ex
+++ b/lib/mix/tasks/dora.gen.handler.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Dora.Gen.Handler do
+  @moduledoc false
   @shortdoc "Generates an Handler for Events"
 
   require Logger
@@ -22,10 +23,10 @@ defmodule Mix.Tasks.Dora.Gen.Handler do
       |> Utils.parse_abi()
 
     abi =
-      if not is_contract do
-        Enum.filter(abi, fn {key, _value} -> key == module end)
-      else
+      if is_contract do
         abi
+      else
+        Enum.filter(abi, fn {key, _value} -> key == module end)
       end
 
     template_data = [

--- a/lib/mix/tasks/utils.ex
+++ b/lib/mix/tasks/utils.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.Utils do
+  @moduledoc false
   require Logger
 
   @event_dispatcher_path "lib/dora/event_dispatcher.ex"
@@ -71,7 +72,8 @@ defmodule Mix.Tasks.Utils do
     if String.contains?(file, content_to_inject) do
       :ok
     else
-      Mix.shell().info([:green, "* injecting ", :reset, Path.relative_to_cwd(file_path)])
+      path = Path.relative_to_cwd(file_path)
+      Mix.shell().info([:green, "* injecting ", :reset, path])
 
       file
       |> String.replace(content_to_replace, content_to_inject)


### PR DESCRIPTION
Why:
 - There were `mix credo` suggestions to fix.
 - The RPC call to obtain the Events list has a maximum range of 60480 blocks. This way when starting to explore an existing contract it's necessary to check if this difference is higher than the maximum range.

How:
 - Making the changes suggested by `mix credo`.
 - Requesting Previous Events in batches if the difference of `latest_block - latest_known_block` is higher than the maximum range.
 - Better handling when starting/restarting indexing contracts.