### PR TITLE
Filter Removed Logs and deployment fixes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -16,16 +16,7 @@ config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
 
-http_rpc_endpoint =
-  System.get_env("HTTP_RPC_ENDPOINT") ||
-    raise """
-    environment variable HTTP_RPC_ENDPOINT is missing.
-    For example: https://api.hyperspace.node.glif.io/rpc/v1
-    """
-
-config :dora, :explorer,
-  refresh_rate: 60_000,
-  http_rpc_endpoint: http_rpc_endpoint
+config :dora, :explorer, refresh_rate: 10_000
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/lib/dora/explorer.ex
+++ b/lib/dora/explorer.ex
@@ -43,6 +43,7 @@ defmodule Dora.Explorer do
   def handle_info(:request_logs, state) do
     events =
       HttpRpc.events(state.address, state.last_block)
+      |> Enum.filter(&(not &1["removed"]))
       |> tap(&Logger.info("Detected #{length(&1)} new Events for: #{state.address}"))
       |> Enum.sort_by(&Utils.hex_to_int(&1["blockNumber"]))
 

--- a/lib/dora/explorer/http_rpc.ex
+++ b/lib/dora/explorer/http_rpc.ex
@@ -6,16 +6,15 @@ defmodule Dora.Explorer.HttpRpc do
 
   alias Dora.Utils
 
-  @http_rpc Application.compile_env!(:dora, :explorer)[:http_rpc_endpoint]
   @maximum_blocks_from_the_past 60_400
 
-  plug(Tesla.Middleware.BaseUrl, @http_rpc)
+  plug(Tesla.Middleware.BaseUrl, get_rpc_endpoint())
   plug(Tesla.Middleware.Headers, [{"accept", "*/*"}])
   plug(Tesla.Middleware.JSON)
 
   def latest_block do
     body = %{
-      id: 1,
+      id: UUID.uuid4(),
       jsonrpc: "2.0",
       method: "Filecoin.EthBlockNumber",
       params: []
@@ -71,5 +70,13 @@ defmodule Dora.Explorer.HttpRpc do
   defp handle_events(_, address, from_block) do
     Logger.error("Error requesting events: #{address} from block: #{from_block}")
     []
+  end
+
+  defp get_rpc_endpoint do
+    System.get_env("HTTP_RPC_ENDPOINT") ||
+      raise """
+      environment variable HTTP_RPC_ENDPOINT is missing.
+      For example: https://api.hyperspace.node.glif.io/rpc/v1
+      """
   end
 end


### PR DESCRIPTION
Why:
 - The RPC endpoint was badly configured to work in the deployed version. When setting a secret var in Fly.io it's not available at compile time.
 - Apparently, there are logs (events) that can be removed after a chain re-org. To avoid repeated events in our DB we need to filter the ones that were removed. (Props to @DavideSilva  for finding [this one](https://github.com/filecoin-project/lotus/blob/master/chain/types/ethtypes/eth_types.go#L638).)

How:
 - Accessing the RPC endpoint variable at runtime.
 - After receiving the list of events from the RPC call, use `Enum.filter` to drop the ones that have the field `"removed" => true`.