### PR TITLE
Store Tx, Block Hashes and Log Index for Events

### DIFF
--- a/lib/dora/event_dispatcher.ex
+++ b/lib/dora/event_dispatcher.ex
@@ -3,26 +3,26 @@ defmodule Dora.EventDispatcher do
 
   require Logger
 
-  def dispatch(contract_address, {:error, decoded_event}) do
+  def dispatch(contract_address, {:error, decoded_event}, _) do
     Logger.error(
       "Couldn't find a matching Event for #{contract_address}: #{inspect(decoded_event)}"
     )
   end
 
-  def dispatch(contract_address, {abi_selector, decoded_event}) do
+  def dispatch(contract_address, {abi_selector, decoded_event}, original_event) do
     event_type = abi_selector.function
 
     event_type
     |> Macro.underscore()
-    |> handle(contract_address, {abi_selector, decoded_event})
+    |> handle(contract_address, {abi_selector, decoded_event}, original_event)
   end
 
   # If we want to deal with the event without worrying on the address
   # Default behaviour for all Transfer events
   #
   # Remove this if you don't need it in your handlers
-  def handle("transfer", address, event) do
-    Dora.Handlers.Defaults.Transfer.apply(address, event)
+  def handle("transfer", address, event, original_event) do
+    Dora.Handlers.Defaults.Transfer.apply(address, event, original_event)
   end
 
   def handle(type, address, _event) do

--- a/lib/dora/events/event.ex
+++ b/lib/dora/events/event.ex
@@ -5,13 +5,16 @@ defmodule Dora.Events.Event do
 
   import Ecto.Changeset
 
-  @fields [:contract_address, :event_type, :event_args]
+  @fields [:contract_address, :event_type, :event_args, :block_hash, :tx_hash, :log_index]
 
   @primary_key {:id, :binary_id, autogenerate: true}
   schema "events" do
     field(:contract_address, :string)
     field(:event_type, :string)
     field(:event_args, :map)
+    field(:block_hash, :string)
+    field(:tx_hash, :string)
+    field(:log_index, :string)
 
     timestamps()
   end
@@ -20,5 +23,6 @@ defmodule Dora.Events.Event do
     indexer_store
     |> cast(params, @fields)
     |> validate_required(@fields)
+    |> unique_constraint([:tx_hash, :log_index])
   end
 end

--- a/lib/dora/explorer.ex
+++ b/lib/dora/explorer.ex
@@ -68,7 +68,7 @@ defmodule Dora.Explorer do
         Utils.pad_data_string(message["data"] || "0x")
       )
 
-    EventDispatcher.dispatch(state.address, decoded_event)
+    EventDispatcher.dispatch(state.address, decoded_event, message)
   end
 
   defp update_last_block_known(state, []), do: state

--- a/lib/dora/handlers/defaults/transfer.ex
+++ b/lib/dora/handlers/defaults/transfer.ex
@@ -6,7 +6,7 @@ defmodule Dora.Handlers.Defaults.Transfer do
   alias Dora.{Events, Projections, Repo}
   alias Dora.Utils
 
-  def apply(address, {_function, topics}) do
+  def apply(address, {_function, topics}, original_event) do
     topics_map = Utils.build_topics_maps(topics)
 
     new_owner = topics_map["to"]
@@ -22,7 +22,10 @@ defmodule Dora.Handlers.Defaults.Transfer do
       Events.create_event(%{
         event_type: "transfer",
         contract_address: address,
-        event_args: transfer
+        event_args: transfer,
+        block_hash: original_event["blockHash"],
+        tx_hash: original_event["transactionHash"],
+        log_index: original_event["logIndex"]
       })
 
       Projections.insert_or_update_event_projection(

--- a/lib/mix/tasks/utils.ex
+++ b/lib/mix/tasks/utils.ex
@@ -43,8 +43,8 @@ defmodule Mix.Tasks.Utils do
 
     content_to_inject =
       """
-      def handle("#{event_name}", address, event) do
-          Dora.Handlers.Defaults.#{module}.apply(address, event)
+      def handle("#{event_name}", address, event, original_event) do
+          Dora.Handlers.Defaults.#{module}.apply(address, event, original_event)
         end
 
       """ <> "  #{content_to_replace}"
@@ -53,13 +53,14 @@ defmodule Mix.Tasks.Utils do
   end
 
   def insert_new_dispatcher_handler(module, event_name, contract_address) do
-    content_to_replace = "|> handle(contract_address, {abi_selector, decoded_event})\n  end\n"
+    content_to_replace =
+      "|> handle(contract_address, {abi_selector, decoded_event}, original_event)\n  end\n"
 
     content_to_inject =
       "#{content_to_replace} \n" <>
         """
-          def handle("#{event_name}", "#{contract_address}", event) do
-            Dora.Handlers.Contracts.#{module}.apply("#{event_name}", "#{contract_address}", event)
+          def handle("#{event_name}", "#{contract_address}", event, original_event) do
+            Dora.Handlers.Contracts.#{module}.apply("#{event_name}", "#{contract_address}", event, original_event)
           end
         """
 

--- a/priv/repo/migrations/20230215143310_add_tx_and_block_hash_to_events.exs
+++ b/priv/repo/migrations/20230215143310_add_tx_and_block_hash_to_events.exs
@@ -1,0 +1,13 @@
+defmodule Dora.Repo.Migrations.AddTxAndBlockHashToEvents do
+  use Ecto.Migration
+
+  def change do
+    alter table(:events) do
+      add(:tx_hash, :string)
+      add(:block_hash, :string)
+      add(:log_index, :string)
+    end
+
+    create(unique_index(:events, [:tx_hash, :log_index], name: :unique_event))
+  end
+end

--- a/priv/templates/dora.gen.handler/handler.ex
+++ b/priv/templates/dora.gen.handler/handler.ex
@@ -27,7 +27,7 @@ defmodule Dora.Handlers.<%= @module_prefix %>.<%= @module_name %> do
   #
   # - Many other things.
   <%= for {type, args} <- @abi do %>
-  def apply(<%= if not is_nil(@address), do: "#{inspect Macro.underscore(type)}, "  %>address, {_function, topics}) do
+  def apply(<%= if not is_nil(@address), do: "#{inspect Macro.underscore(type)}, "  %>address, {_function, topics}, original_event) do
     topics_map = Utils.build_topics_maps(topics)
 
     <%= Macro.underscore(type) %> = %{
@@ -38,7 +38,10 @@ defmodule Dora.Handlers.<%= @module_prefix %>.<%= @module_name %> do
       Events.create_event(%{
         event_type: "<%= Macro.underscore(type) %>",
         contract_address: address,
-        event_args: <%= Macro.underscore(type) %>
+        event_args: <%= Macro.underscore(type) %>,
+        block_hash: original_event["blockHash"],
+        tx_hash: original_event["transactionHash"],
+        log_index: original_event["logIndex"]
       })
 
       # Other code you may want to add inside the Transaction


### PR DESCRIPTION
Why:
 - As referenced in a comment from the previous PR. https://github.com/finiam/dora-the-tipset-explorer/pull/4#discussion_r1107237243, we need to start storing transaction and block hashes and also the Log Index for Events. This way we can ensure at the Database Level that we won't have repeated events.

How:
 - Creating a new index to be unique by `:tx_hash`, `:block_hash` and `:log_index`.
 - Update code to pass the original event up to the handler.
 - Update the handler's code generation to also take this into account.